### PR TITLE
fix: set VideoQuality.VERY_HIGH to very_high to match movilite.VideoQ…

### DIFF
--- a/src/pycaps/common/types.py
+++ b/src/pycaps/common/types.py
@@ -5,7 +5,7 @@ class VideoQuality(str, Enum):
     LOW = "low"
     MIDDLE = "middle"
     HIGH = "high"
-    VERY_HIGH = "veryhigh"
+    VERY_HIGH = "very_high"
 
 class CacheStrategy(str, Enum):
     CSS_CLASSES_AWARE = "css-classes-aware" # two words with same CSS classes, same text are considered equal (word position on line is ignored)


### PR DESCRIPTION
Stumbled across the error `ValueError: 'veryhigh' is not a valid VideoQuality`

matching the enums fixes this.