### PR TITLE
feat: Add --whisper-prompt option for custom vocabulary hints

### DIFF
--- a/src/pycaps/cli/render_cli.py
+++ b/src/pycaps/cli/render_cli.py
@@ -55,6 +55,7 @@ def render(
 
     language: Optional[str] = typer.Option(None, "--lang", help="Language of the video, example: --lang=en", rich_help_panel="Whisper", show_default=False),
     whisper_model: Optional[str] = typer.Option(None, "--whisper-model", help="Whisper model to use, example: --whisper-model=base", rich_help_panel="Whisper", show_default=False),
+    whisper_prompt: Optional[str] = typer.Option(None, "--whisper-prompt", help="Vocabulary hints for Whisper to improve accuracy (e.g., 'BrandName, TechTerm')", rich_help_panel="Whisper", show_default=False),
 
     video_quality: Optional[VideoQuality] = typer.Option(None, "--video-quality", help="Final video quality", rich_help_panel="Video", show_default=False),
 
@@ -82,7 +83,7 @@ def render(
     if output: builder.with_output_video(output)
     if style: builder.add_css_content(_parse_styles(style))
     # TODO: this has a little issue (if you set lang via js + whisper model by cli, it will change the lang to None)
-    if language or whisper_model: builder.with_whisper_config(language=language, model_size=whisper_model if whisper_model else "base")
+    if language or whisper_model or whisper_prompt: builder.with_whisper_config(language=language, model_size=whisper_model if whisper_model else "base", initial_prompt=whisper_prompt)
     if subtitle_data: builder.with_subtitle_data_path(subtitle_data)
     if transcription_preview: builder.should_preview_transcription(True)
     if video_quality: builder.with_video_quality(video_quality)

--- a/src/pycaps/pipeline/caps_pipeline_builder.py
+++ b/src/pycaps/pipeline/caps_pipeline_builder.py
@@ -58,8 +58,8 @@ class CapsPipelineBuilder:
         self._caps_pipeline._renderer = subtitle_renderer
         return self
     
-    def with_whisper_config(self, language: Optional[str] = None, model_size: str = "base") -> "CapsPipelineBuilder":
-        self._caps_pipeline._transcriber = WhisperAudioTranscriber(model_size=model_size, language=language)
+    def with_whisper_config(self, language: Optional[str] = None, model_size: str = "base", initial_prompt: Optional[str] = None) -> "CapsPipelineBuilder":
+        self._caps_pipeline._transcriber = WhisperAudioTranscriber(model_size=model_size, language=language, initial_prompt=initial_prompt)
         return self
     
     def with_custom_audio_transcriber(self, audio_transcriber: AudioTranscriber) -> "CapsPipelineBuilder":

--- a/src/pycaps/transcriber/whisper_audio_transcriber.py
+++ b/src/pycaps/transcriber/whisper_audio_transcriber.py
@@ -4,7 +4,7 @@ from pycaps.common import Document, Segment, Line, Word, TimeFragment
 from pycaps.logger import logger
 
 class WhisperAudioTranscriber(AudioTranscriber):
-    def __init__(self, model_size: str = "base", language: Optional[str] = None, model: Optional[Any] = None):
+    def __init__(self, model_size: str = "base", language: Optional[str] = None, model: Optional[Any] = None, initial_prompt: Optional[str] = None):
         """
         Transcribes audio using OpenAI's Whisper model.
 
@@ -12,10 +12,12 @@ class WhisperAudioTranscriber(AudioTranscriber):
             model_size: Size of the Whisper model to use (e.g., "tiny", "base").
             language: Language of the audio (e.g., "en", "es").
             model: (Optional) A pre-loaded Whisper model instance. If provided, model_size is ignored.
+            initial_prompt: (Optional) Vocabulary hints for Whisper to improve accuracy on specific words (e.g., brand names).
         """
         self._model_size = model_size
         self._language = language
         self._model = model
+        self._initial_prompt = initial_prompt
 
     def transcribe(self, audio_path: str) -> Document:
         """
@@ -25,6 +27,7 @@ class WhisperAudioTranscriber(AudioTranscriber):
             audio_path,
             word_timestamps=True,
             language=self._language,
+            initial_prompt=self._initial_prompt,
             verbose=False # TODO: we should pass our --verbose param here
         )
 


### PR DESCRIPTION
## Summary

Adds the ability to pass vocabulary hints to Whisper's `initial_prompt` parameter for improved transcription accuracy on brand names, technical terms, and other uncommon words.

## Problem

When transcribing audio that contains brand names or technical terms, Whisper often misinterprets them. For example:
- "PlateLens" gets transcribed as "Platelins"
- Brand names and proper nouns are frequently incorrect

## Solution

Whisper already supports an `initial_prompt` parameter that can hint the model about expected vocabulary. This PR exposes that parameter through a new `--whisper-prompt` CLI option.

## Usage

```bash
pycaps render --input video.mp4 --template hype --whisper-prompt "PlateLens, BrandName"
```

## Changes

| File | Change |
|------|--------|
| `whisper_audio_transcriber.py` | Accept `initial_prompt` parameter in `__init__` and pass to Whisper's transcribe |
| `caps_pipeline_builder.py` | Add `initial_prompt` parameter to `with_whisper_config()` |
| `render_cli.py` | Add `--whisper-prompt` CLI option in Whisper panel |

## Benefits

- ✅ Minimal code change (< 10 lines total)
- ✅ Backward compatible (optional parameter, defaults to None)
- ✅ Leverages existing Whisper capability
- ✅ Significantly improves accuracy for brand names and technical terms
- ✅ No external dependencies

## References

- [Whisper initial_prompt documentation](https://github.com/openai/whisper/discussions/355)
- [Improving Whisper accuracy with prompts](https://medium.com/axinc-ai/prompt-engineering-in-whisper-6bb18003562d)